### PR TITLE
Maintenance: Update OpenJDK, Docker Buildx and Ubuntu LTS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
       - run:
           name: Install Docker buildx
           command: |
-            sudo wget https://github.com/docker/buildx/releases/download/v0.3.1/buildx-v0.3.1.linux-amd64 -O /usr/local/bin/docker-buildx
+            sudo wget https://github.com/docker/buildx/releases/download/v0.5.1/buildx-v0.5.1.linux-amd64 -O /usr/local/bin/docker-buildx
             sudo chmod a+x /usr/local/bin/docker-buildx
             sudo systemctl restart docker
       - run:
@@ -52,7 +52,7 @@ jobs:
       - run:
           name: Install Docker buildx
           command: |
-            sudo wget https://github.com/docker/buildx/releases/download/v0.3.1/buildx-v0.3.1.linux-amd64 -O /usr/local/bin/docker-buildx
+            sudo wget https://github.com/docker/buildx/releases/download/v0.5.1/buildx-v0.5.1.linux-amd64 -O /usr/local/bin/docker-buildx
             sudo chmod a+x /usr/local/bin/docker-buildx
             sudo systemctl restart docker
       - run:

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@
 VERSION                 := localbuild
 SHELL                   := /bin/bash -o nounset -o pipefail -o errexit
 BUILD_DATE              := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
-BASE_IMAGE              := ubuntu:focal
+BASE_IMAGE              := ubuntu:focal-20201106
 DOCKER_CLI_EXPERIMENTAL := enabled
 DOCKERX_INSTANCE	      := env-deploy-base-oci
 DOCKER_REGISTRY         := docker.io
@@ -23,7 +23,7 @@ BUILD_NUMBER            := "unset"
 BUILD_URL               := "unset"
 BUILD_BRANCH            := $(shell git describe --always)
 JAVA_MAJOR_VERSION      := 11
-JAVA_PKG_VERSION        := 11.0.7+10-2ubuntu1
+JAVA_PKG_VERSION        := 11.0.9.1+1-0ubuntu1~20.04
 JAVA_PKG                := openjdk-$(JAVA_MAJOR_VERSION)-jre-headless=$(JAVA_PKG_VERSION)
 JICMP_VERSION           := "jicmp-2.0.5-1"
 JICMP6_VERSION          := "jicmp6-2.0.4-1"


### PR DESCRIPTION
Update base image to use Ubuntu LTS focal, OpenJDK and Docker buildx.

* Ubuntu Focal to Focal 2020-11-06
* OpenJDK update from 11.0.7 to 11.0.9
* Docker Buildx from 0.3.1 to 0.5.1