### PR TITLE
NMS-13276: Fix TZ environment variable to set time zone

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,7 @@ RUN git clone ${JICMP6_GIT_REPO_URL} ${JICMP6_SRC} && \
 FROM ${BASE_IMAGE}
 
 ARG JAVA_MAJOR_VERSION=11
-ARG JAVA_PKG_VERSION=11.0.7+10-2ubuntu1
+ARG JAVA_PKG_VERSION=11.0.7+10-3ubuntu1
 ARG JAVA_PKG=openjdk-${JAVA_MAJOR_VERSION}-jre-headless=${JAVA_PKG_VERSION}
 ARG JAVA_HOME=/usr/lib/jvm/java
 
@@ -70,7 +70,7 @@ ARG JAVA_HOME=/usr/lib/jvm/java
 # The JNI Pinger is tested with getprotobyname("icmp") and it is null if inetutils-ping is missing
 # To be able to use DGRAM to send ICMP messages we have to give the java binary CAP_NET_RAW capabilities in Linux.
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends ${JAVA_PKG} openssh-client inetutils-ping libcap2-bin && \
+    apt-get install -y --no-install-recommends ${JAVA_PKG} openssh-client inetutils-ping libcap2-bin tzdata && \
     ln -s /usr/lib/jvm/java-11-openjdk* ${JAVA_HOME} && \
     rm -rf /var/lib/apt/lists/*
 

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ BUILD_NUMBER            := "unset"
 BUILD_URL               := "unset"
 BUILD_BRANCH            := $(shell git describe --always)
 JAVA_MAJOR_VERSION      := 11
-JAVA_PKG_VERSION        := 11.0.9.1+1-0ubuntu1~20.04
+JAVA_PKG_VERSION        := 11.0.7+10-3ubuntu1
 JAVA_PKG                := openjdk-$(JAVA_MAJOR_VERSION)-jre-headless=$(JAVA_PKG_VERSION)
 JICMP_VERSION           := "jicmp-2.0.5-1"
 JICMP6_VERSION          := "jicmp6-2.0.4-1"


### PR DESCRIPTION
### Minion deploy base image

The time zone setting with the environment variable TZ can be used and the tzdata package was added which provides the time zone files to work properly.

### Reviewer Hint:

Ubuntu focal updated to OpenJDK 11 JRE 11.0.11 and only 11.0.7 as an older version is available in the repository. I picked a defensive option here. We ran in an issue with 11.0.11 in [NMS-13111](https://issues.opennms.org/browse/NMS-13111) which prevents upgrading beyond 11.0.10+.

JIRA: https://issues.opennms.org/browse/NMS-13276