### PR TITLE
NMS-13318: Sign image for use with Docker Content Trust

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ aliases:
       echo "export IMAGE=docker.io/${DOCKER_ORG}/deploy-base" >> $BASH_ENV
       echo "export VERSION=jre-1.2.0.b<< pipeline.number >>" >> $BASH_ENV
     environment:
-      DOCKER_ORG: opennmsdcttest
+      DOCKER_ORG: opennms
 
   - &load_dct_keys
     name: Load signer key
@@ -28,6 +28,7 @@ aliases:
       KEY_FOLDER=~/.docker/trust/private
       mkdir -p $KEY_FOLDER
       echo "$DCT_DELEGATE_KEY" | base64 -d > $KEY_FOLDER/$DCT_DELEGATE_KEY_NAME.key
+      echo "done first decoding"
       echo "$DCT_REPO_DEPLOY_BASE_KEY" | base64 -d > $KEY_FOLDER/$DCT_REPO_DEPLOY_BASE_KEY_NAME.key
       chmod 600 $KEY_FOLDER/*
       docker trust key load $KEY_FOLDER/$DCT_DELEGATE_KEY_NAME.key
@@ -44,7 +45,7 @@ jobs:
       - run: *load_dct_keys
       - run:
           name: multiarch/qemu-user-static
-          command: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+          command: DOCKER_CONTENT_TRUST=0 docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
       - run:
           name: Install Docker buildx
           command: |
@@ -154,7 +155,6 @@ workflows:
           filters:
             branches:
               ignore:
-                - jira/NMS-13318
                 - master
       - build-publish-single-arch:
           matrix:
@@ -164,7 +164,6 @@ workflows:
           filters:
             branches:
               only:
-                - jira/NMS-13318
                 - master
       - publish-multi-arch:
           context: "docker-content-trust"
@@ -173,5 +172,4 @@ workflows:
           filters:
             branches:
               only:
-                - jira/NMS-13318
                 - master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,28 @@ commands:
           command: |
             docker login -u ${DOCKERHUB_LOGIN} -p ${DOCKERHUB_PASS}
 
+aliases:
+  - &setup_dct_env
+    name: Setup DCT environment
+    command: |
+      echo "export DOCKER_ORG=${DOCKER_ORG}" >> $BASH_ENV
+      echo "export DOCKER_CONTENT_TRUST=1" >> $BASH_ENV
+      echo "export DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE=\"$DCT_DELEGATE_KEY_PASSPHRASE\"" >> $BASH_ENV
+      echo "export IMAGE=docker.io/${DOCKER_ORG}/deploy-base" >> $BASH_ENV
+      echo "export VERSION=jre-1.2.0.b<< pipeline.number >>" >> $BASH_ENV
+    environment:
+      DOCKER_ORG: opennmsdcttest
+
+  - &load_dct_keys
+    name: Load signer key
+    command: |
+      KEY_FOLDER=~/.docker/trust/private
+      mkdir -p $KEY_FOLDER
+      echo "$DCT_DELEGATE_KEY" | base64 -d > $KEY_FOLDER/$DCT_DELEGATE_KEY_NAME.key
+      echo "$DCT_REPO_DEPLOY_BASE_KEY" | base64 -d > $KEY_FOLDER/$DCT_REPO_DEPLOY_BASE_KEY_NAME.key
+      chmod 600 $KEY_FOLDER/*
+      docker trust key load $KEY_FOLDER/$DCT_DELEGATE_KEY_NAME.key
+
 jobs:
   build:
     machine:
@@ -18,6 +40,8 @@ jobs:
       DOCKER_CLI_EXPERIMENTAL: enabled
     steps:
       - checkout
+      - run: *setup_dct_env
+      - run: *load_dct_keys
       - run:
           name: multiarch/qemu-user-static
           command: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
@@ -38,7 +62,10 @@ jobs:
           paths:
             - project/artifacts
 
-  build-publish:
+  build-publish-single-arch:
+    parameters:
+      architecture:
+        type: string
     machine:
       image: ubuntu-2004:202010-01
     environment:
@@ -46,9 +73,11 @@ jobs:
     steps:
       - checkout
       - dockerhub-login
+      - run: *setup_dct_env
+      - run: *load_dct_keys
       - run:
           name: multiarch/qemu-user-static
-          command: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+          command: DOCKER_CONTENT_TRUST=0 docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
       - run:
           name: Install Docker buildx
           command: |
@@ -56,20 +85,93 @@ jobs:
             sudo chmod a+x /usr/local/bin/docker-buildx
             sudo systemctl restart docker
       - run:
-          name: Multi-arch build
-          command: make VERSION="jre-1.2.0.b${CIRCLE_BUILD_NUM}" DOCKER_FLAGS=--push DOCKER_ARCH=linux/amd64,linux/arm64,linux/arm/v7
+          name: Single-arch build & push
+          command: |
+            ARCH="$(printf "<< parameters.architecture >>" | tr / -)"
+            TAG="${VERSION}-${ARCH}"
+            make VERSION="${TAG}" DOCKER_ORG="${DOCKER_ORG}" DOCKER_FLAGS=--load DOCKER_ARCH=<< parameters.architecture >>
+            docker push ${IMAGE}:${TAG}
+
+  publish-multi-arch:
+    machine:
+      image: ubuntu-2004:202010-01
+    environment:
+      DOCKER_CLI_EXPERIMENTAL: enabled
+    steps:
+      - dockerhub-login
+      - run: *setup_dct_env
+      - run: *load_dct_keys
+      - run:
+          name: Install notary
+          command: |
+            sudo wget https://github.com/theupdateframework/notary/releases/download/v0.6.1/notary-Linux-amd64 -O /usr/local/bin/notary
+            sudo chmod a+x /usr/local/bin/notary
+      - run:
+          name: Create & push multi-arch manifest
+          command: |
+            IMAGE_REF="${IMAGE}:${VERSION}"
+            docker manifest create ${IMAGE_REF} \
+              ${IMAGE_REF}-linux-amd64 \
+              ${IMAGE_REF}-linux-arm64 \
+              ${IMAGE_REF}-linux-arm-v7 \
+              --amend
+            SHA_256="$(docker manifest push "${IMAGE_REF}" --purge | cut -d ':' -f 2)"
+            echo "Manifest SHA-256: ${SHA_256}"
+            echo "Image-Ref: ${IMAGE_REF}"
+            MANIFEST_FROM_REG="$(docker manifest inspect "${IMAGE_REF}" -v)";
+            BYTES_SIZE="$(printf "${MANIFEST_FROM_REG}" | jq -r '.[].Descriptor.size' | uniq)";
+            echo "Manifest-inspect BYTES: ${BYTES_SIZE}";
+            echo "Manifest contents:\n";
+            printf "${MANIFEST_FROM_REG}" | jq -r '.[].Descriptor | "Architecture: " + .platform.architecture + .platform.variant + ", digest: " + .digest';
+            export NOTARY_AUTH="$(printf "${DOCKERHUB_LOGIN}:${DOCKERHUB_PASS}" | base64 -w0)"
+            echo "Sign ${SHA_256} with the notary"
+            # when the multi-arch image is signed by the delegate key then docker pull reports "No valid trust data..."
+            # -> the following lines can not be used:
+            #
+            # export NOTARY_DELEGATION_PASSPHRASE="${DCT_DELEGATE_KEY_PASSPHRASE}"
+            # notary -d ~/.docker/trust/ -s https://notary.docker.io addhash "${IMAGE}" "${VERSION}" 946 --sha256 "${SHA_256}" --roles targets/opennms-circle-delegate --publish --verbose
+            #
+            # -> use the targets key of the deploy-base repository to sign the multi-arch image instead
+            export NOTARY_TARGETS_PASSPHRASE="${DCT_REPO_DEPLOY_BASE_KEY_PASSPHRASE}"
+            notary -d ~/.docker/trust/ -s https://notary.docker.io addhash "${IMAGE}" "${VERSION}" "${BYTES_SIZE}" --sha256 "${SHA_256}" --publish --verbose
+            echo "Done!"
+            # notary -s https://notary.docker.io list "${IMAGE}"
+
+# docker-buildx does not support signing multi-arch images
+# cf. - https://github.com/docker/buildx/issues/313
+#     - https://github.com/sudo-bot/action-docker-sign#sign-multi-platform-manifests
+#
+# -> build and sign the images for each architecture separately
+# -> create a manifest for the multi-arch image and push it
+# -> use notary to sign the manifest (this needs the targets key of the deploy-base repository)
 
 workflows:
   version: 2
   main:
     jobs:
       - build:
+          context: "docker-content-trust"
           filters:
             branches:
               ignore:
+                - jira/NMS-13318
                 - master
-      - build-publish:
+      - build-publish-single-arch:
+          matrix:
+            parameters:
+              architecture: [linux/amd64,linux/arm64,linux/arm/v7]
+          context: "docker-content-trust"
           filters:
             branches:
               only:
+                - jira/NMS-13318
+                - master
+      - publish-multi-arch:
+          context: "docker-content-trust"
+          requires:
+            - build-publish-single-arch
+          filters:
+            branches:
+              only:
+                - jira/NMS-13318
                 - master

--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,6 @@ build: test
 	@docker-buildx use $(DOCKERX_INSTANCE);
 	@echo "Build container image for architecture: $(DOCKER_ARCH) ..."
 	BASE_IMAGE=${BASE_IMAGE} envsubst '$$BASE_IMAGE' < Dockerfile > SubstitutedDockerfile
-	@echo "DOCKER_CONTENT_TRUST: $${DOCKER_CONTENT_TRUST=1}"
 	docker-buildx build --file SubstitutedDockerfile \
 	--platform=$(DOCKER_ARCH) \
     --build-arg BASE_IMAGE=$(BASE_IMAGE) \

--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,10 @@ build: test
 	@if ! docker-buildx inspect $(DOCKERX_INSTANCE); then docker-buildx create --name $(DOCKERX_INSTANCE); fi;
 	@docker-buildx use $(DOCKERX_INSTANCE);
 	@echo "Build container image for architecture: $(DOCKER_ARCH) ..."
-	docker-buildx build --platform=$(DOCKER_ARCH) \
+	BASE_IMAGE=${BASE_IMAGE} envsubst '$$BASE_IMAGE' < Dockerfile > SubstitutedDockerfile
+	@echo "DOCKER_CONTENT_TRUST: $${DOCKER_CONTENT_TRUST=1}"
+	docker-buildx build --file SubstitutedDockerfile \
+	--platform=$(DOCKER_ARCH) \
     --build-arg BASE_IMAGE=$(BASE_IMAGE) \
     --build-arg VERSION=$(VERSION) \
     --build-arg BUILD_DATE=$(BUILD_DATE) \


### PR DESCRIPTION
Issue: https://issues.opennms.org/browse/NMS-13318

* Build images for each architecture separately
* Create a manifest for the multi-arch image manually and sign it

Before this PR can be merged the following things have to be done:

* change the `DOCKER_ORG: opennmsdcttest` setting in `config.yml` to `DOCKER_ORG: opennms`
* remove the `ira/NMS-13318` branch selections from `config.yml`
* change the `docker-content-trust` build context to contain the DCT credentials of the `opennms` docker hub organization
