### PR TITLE
Add JMX Prometheus exporter, wget and ca certificate package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,6 +63,8 @@ ARG JAVA_MAJOR_VERSION=11
 ARG JAVA_PKG_VERSION=11.0.7+10-3ubuntu1
 ARG JAVA_PKG=openjdk-${JAVA_MAJOR_VERSION}-jre-headless=${JAVA_PKG_VERSION}
 ARG JAVA_HOME=/usr/lib/jvm/java
+ARG PROM_JMX_EXPORTER_VERSION="0.16.0"
+ARG PROM_JMX_EXPORTER_URL="https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/${PROM_JMX_EXPORTER_VERSION}/jmx_prometheus_javaagent-${PROM_JMX_EXPORTER_VERSION}.jar"
 
 # Install OPenJDK 11 and create an architecture independent Java directory
 # which can be used as Java Home.
@@ -70,9 +72,12 @@ ARG JAVA_HOME=/usr/lib/jvm/java
 # The JNI Pinger is tested with getprotobyname("icmp") and it is null if inetutils-ping is missing
 # To be able to use DGRAM to send ICMP messages we have to give the java binary CAP_NET_RAW capabilities in Linux.
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends ${JAVA_PKG} openssh-client inetutils-ping libcap2-bin tzdata && \
+    apt-get install -y --no-install-recommends ${JAVA_PKG} wget ca-certificates openssh-client inetutils-ping libcap2-bin tzdata && \
     ln -s /usr/lib/jvm/java-11-openjdk* ${JAVA_HOME} && \
-    rm -rf /var/lib/apt/lists/*
+    update-ca-certificates -f && \
+    rm -rf /var/lib/apt/lists/* && \
+    mkdir -p /opt/prom-jmx-exporter && \
+    wget "${PROM_JMX_EXPORTER_URL}" --output-document=/opt/prom-jmx-exporter/jmx_prometheus_javaagent.jar
 
 # Install confd
 COPY --from=confd-build /usr/local/bin/confd /usr/local/bin/confd

--- a/Makefile
+++ b/Makefile
@@ -5,28 +5,29 @@
 
 .DEFAULT_GOAL := build
 
-VERSION                 := localbuild
-SHELL                   := /bin/bash -o nounset -o pipefail -o errexit
-BUILD_DATE              := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
-BASE_IMAGE              := ubuntu:focal-20201106
-DOCKER_CLI_EXPERIMENTAL := enabled
-DOCKERX_INSTANCE	      := env-deploy-base-oci
-DOCKER_REGISTRY         := docker.io
-DOCKER_ORG              := opennms
-DOCKER_PROJECT          := deploy-base
-DOCKER_TAG              := $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(DOCKER_PROJECT):$(VERSION)
-DOCKER_ARCH             := linux/amd64
-DOCKER_FLAGS            := --output=type=docker,dest=artifacts/deploy-base.oci
-SOURCE                  := $(shell git remote get-url origin)
-REVISION                := $(shell git describe --always)
-BUILD_NUMBER            := "unset"
-BUILD_URL               := "unset"
-BUILD_BRANCH            := $(shell git describe --always)
-JAVA_MAJOR_VERSION      := 11
-JAVA_PKG_VERSION        := 11.0.7+10-3ubuntu1
-JAVA_PKG                := openjdk-$(JAVA_MAJOR_VERSION)-jre-headless=$(JAVA_PKG_VERSION)
-JICMP_VERSION           := "jicmp-2.0.5-1"
-JICMP6_VERSION          := "jicmp6-2.0.4-1"
+VERSION                    := localbuild
+SHELL                      := /bin/bash -o nounset -o pipefail -o errexit
+BUILD_DATE                 := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
+BASE_IMAGE                 := ubuntu:focal-20210609
+DOCKER_CLI_EXPERIMENTAL    := enabled
+DOCKERX_INSTANCE           := env-deploy-base-oci
+DOCKER_REGISTRY            := docker.io
+DOCKER_ORG                 := opennms
+DOCKER_PROJECT             := deploy-base
+DOCKER_TAG                 := $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(DOCKER_PROJECT):$(VERSION)
+DOCKER_ARCH                := linux/amd64
+DOCKER_FLAGS               := --output=type=docker,dest=artifacts/deploy-base.oci
+SOURCE                     := $(shell git remote get-url origin)
+REVISION                   := $(shell git describe --always)
+BUILD_NUMBER               := "unset"
+BUILD_URL                  := "unset"
+BUILD_BRANCH               := $(shell git describe --always)
+JAVA_MAJOR_VERSION         := 11
+JAVA_PKG_VERSION           := 11.0.11+9-0ubuntu2~20.04
+JAVA_PKG                   := openjdk-$(JAVA_MAJOR_VERSION)-jre-headless=$(JAVA_PKG_VERSION)
+JICMP_VERSION              := jicmp-2.0.5-1
+JICMP6_VERSION             := jicmp6-2.0.4-1
+PROM_JMX_EXPORTER_VERSION  := 0.16
 
 help:
 	@echo ""
@@ -46,21 +47,22 @@ help:
 	@echo "  clean-all: Remove the Dockerx build instance and delete *everything* in the directory artifacts/"
 	@echo ""
 	@echo "Arguments to modify the build:"
-	@echo "  VERSION:            Version number for this release of the deploy-base artefact, default: $(VERSION)"
-	@echo "  BASE_IMAGE:         The base image we install our Java app as a tarball, default: $(BASE_IMAGE)"
-	@echo "  DOCKERX_INSTANCE:   Name of the docker buildx instance, default: $(DOCKERX_INSTANCE)"
-	@echo "  DOCKER_REGISTRY:    Registry to push the image to, default is set to $(DOCKER_REGISTRY)"
-	@echo "  DOCKER_ORG:         Organisation where the image should pushed in the registry, default is set to $(DOCKER_ORG)"
-	@echo "  DOCKER_PROJECT:     Name of the project in the registry, the default is set to $(DOCKER_PROJECT)"
-	@echo "  DOCKER_TAG:         Docker tag is generated from registry, org, project, version and build number, set to $(DOCKER_TAG)"
-	@echo "  DOCKER_ARCH:        Architecture for OCI image, default: $(DOCKER_ARCH)"
-	@echo "  DOCKER_FLAGS:       Additional docker buildx flags, by default write a single architecture to a file, default: $(DOCKER_FLAGS)"
-	@echo "  BUILD_NUMBER:       In case we run in CI/CD this is the build number which produced the artifact, default: $(BUILD_NUMBER)"
-	@echo "  BUILD_URL:          In case we run in CI/CD this is the URL which for the build, default: $(BUILD_URL)"
-	@echo "  BUILD_BRANCH:       In case we run in CI/CD this is the branch of the build, default: $(BUILD_BRANCH)"
-	@echo "  JAVA_MAJOR_VERSION: Major version number from Java package, default: $(JAVA_MAJOR_VERSION)"
-	@echo "  JAVA_PKG_VERSION:   Java package version, default: $(JAVA_PKG_VERSION)"
-	@echo "  JAVA_PKG:           Java package to install, default: $(JAVA_PKG)"
+	@echo "  VERSION:                   Version number for this release of the deploy-base artefact, default: $(VERSION)"
+	@echo "  BASE_IMAGE:                The base image we install our Java app as a tarball, default: $(BASE_IMAGE)"
+	@echo "  DOCKERX_INSTANCE:          Name of the docker buildx instance, default: $(DOCKERX_INSTANCE)"
+	@echo "  DOCKER_REGISTRY:           Registry to push the image to, default is set to $(DOCKER_REGISTRY)"
+	@echo "  DOCKER_ORG:                Organisation where the image should pushed in the registry, default is set to $(DOCKER_ORG)"
+	@echo "  DOCKER_PROJECT:            Name of the project in the registry, the default is set to $(DOCKER_PROJECT)"
+	@echo "  DOCKER_TAG:                Docker tag is generated from registry, org, project, version and build number, set to $(DOCKER_TAG)"
+	@echo "  DOCKER_ARCH:               Architecture for OCI image, default: $(DOCKER_ARCH)"
+	@echo "  DOCKER_FLAGS:              Additional docker buildx flags, by default write a single architecture to a file, default: $(DOCKER_FLAGS)"
+	@echo "  BUILD_NUMBER:              In case we run in CI/CD this is the build number which produced the artifact, default: $(BUILD_NUMBER)"
+	@echo "  BUILD_URL:                 In case we run in CI/CD this is the URL which for the build, default: $(BUILD_URL)"
+	@echo "  BUILD_BRANCH:              In case we run in CI/CD this is the branch of the build, default: $(BUILD_BRANCH)"
+	@echo "  JAVA_MAJOR_VERSION:        Major version number from Java package, default: $(JAVA_MAJOR_VERSION)"
+	@echo "  JAVA_PKG_VERSION:          Java package version, default: $(JAVA_PKG_VERSION)"
+	@echo "  JAVA_PKG:                  Java package to install, default: $(JAVA_PKG)"
+	@echo "  PROM_JMX_EXPORTER_VERSION: Prometheus JMX exporter version, default: $(PROM_JMX_EXPORTER_VERSION)"
 	@echo ""
 	@echo "Example:"
 	@echo "  make build DOCKER_REGISTRY=myregistry.com DOCKER_ORG=myorg DOCKER_FLAGS=--push"


### PR DESCRIPTION
* Added Prometheus JMX exporter and bumped version for 0.15 to 0.16
* Bumped OpenJDK from 11.0.7+10-3ubuntu1 to 11.0.11+9-0ubuntu2~20.04, the old one isn't available in the repos anymore
* Bumped Ubuntu Focal from `ubuntu:focal-20201106` to `ubuntu:focal-20210609`

The main motivation here is to remove external repository dependencies from the OpenNMS Horizon CI/CD pipeline with update/installing from remote repositories.