### PR TITLE
NMS-14522: setcap CAP_NET_BIND_SERVICE on java

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ aliases:
       echo "export CONTAINER_REGISTRY_LOGIN=${DOCKERHUB_LOGIN}"
       echo "export CONTAINER_REGISTRY_PASS=${DOCKERHUB_PASS}"
       echo "export IMAGE=${DOCKER_REGISTRY}/${DOCKER_ORG}/deploy-base" >> $BASH_ENV
-      echo "export VERSION=jre-2.0.6.b<< pipeline.number >>" >> $BASH_ENV
+      echo "export VERSION=jre-2.1.0.b<< pipeline.number >>" >> $BASH_ENV
     environment:
       DOCKER_REGISTRY: docker.io
       DOCKER_ORG: opennms

--- a/Dockerfile.tpl
+++ b/Dockerfile.tpl
@@ -106,7 +106,9 @@ RUN apt-get update && \
     mkdir -p /opt/prom-jmx-exporter && \
     curl "${PROM_JMX_EXPORTER_URL}" --output /opt/prom-jmx-exporter/jmx_prometheus_javaagent.jar && \
     \
-    setcap CAP_NET_BIND_SERVICE+ep "${JAVA_HOME}/bin/java"
+    setcap CAP_NET_BIND_SERVICE+ep "${JAVA_HOME}/bin/java" &&
+    echo "${JAVA_HOME}/lib/jli" > /etc/ld.so.conf.d/java-latest.conf && \
+    ldconfig
 
 # Install confd
 COPY --from=confd-build /usr/bin/confd /usr/bin/confd

--- a/Dockerfile.tpl
+++ b/Dockerfile.tpl
@@ -104,7 +104,9 @@ RUN apt-get update && \
     rm -rf /var/cache/apt && \
     \
     mkdir -p /opt/prom-jmx-exporter && \
-    curl "${PROM_JMX_EXPORTER_URL}" --output /opt/prom-jmx-exporter/jmx_prometheus_javaagent.jar
+    curl "${PROM_JMX_EXPORTER_URL}" --output /opt/prom-jmx-exporter/jmx_prometheus_javaagent.jar && \
+    \
+    setcap CAP_NET_BIND_SERVICE+ep "${JAVA_HOME}/bin/java"
 
 # Install confd
 COPY --from=confd-build /usr/bin/confd /usr/bin/confd


### PR DESCRIPTION
This PR updates the deploy base to run `setcap` on the JDK `java` binary.