### PR TITLE
NMS-15328: update deploy-base to support JDK17 in addition to 11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,10 +9,10 @@ aliases:
       echo "export DOCKER_ORG=${DOCKER_ORG}" >> $BASH_ENV
       echo "export DOCKER_CONTENT_TRUST=1" >> $BASH_ENV
       echo "export DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE=\"$DCT_DELEGATE_KEY_PASSPHRASE\"" >> $BASH_ENV
-      echo "export CONTAINER_REGISTRY_LOGIN=${DOCKERHUB_LOGIN}"
-      echo "export CONTAINER_REGISTRY_PASS=${DOCKERHUB_PASS}"
+      echo "export CONTAINER_REGISTRY_LOGIN='${DOCKERHUB_LOGIN}'" >> $BASH_ENV
+      echo "export CONTAINER_REGISTRY_PASS='${DOCKERHUB_PASS}'" >> $BASH_ENV
       echo "export IMAGE=${DOCKER_REGISTRY}/${DOCKER_ORG}/deploy-base" >> $BASH_ENV
-      echo "export VERSION=jre-2.1.0.b<< pipeline.number >>" >> $BASH_ENV
+      echo "export VERSION=ubuntu-3.0.0.b<< pipeline.number >>" >> $BASH_ENV
     environment:
       DOCKER_REGISTRY: docker.io
       DOCKER_ORG: opennms
@@ -33,8 +33,10 @@ jobs:
     parameters:
       architecture:
         type: string
+      jdk:
+        type: string
     machine:
-      image: ubuntu-2204:2022.07.1
+      image: ubuntu-2204:current
     environment:
       DOCKER_CLI_EXPERIMENTAL: enabled
     steps:
@@ -45,7 +47,9 @@ jobs:
       - run:
           name: Single-arch build
           command: |
-            make oci ARCHITECTURE="<< parameters.architecture >>"
+            make oci \
+              ARCHITECTURE="<< parameters.architecture >>" \
+              JAVA_MAJOR_VERSION="<< parameters.jdk >>"
       - store_artifacts:
           path: ~/project/artifacts/
           destination: /
@@ -54,30 +58,10 @@ jobs:
     parameters:
       architecture:
         type: string
+      jdk:
+        type: string
     machine:
-      image: ubuntu-2204:2022.07.1
-    environment:
-      DOCKER_CLI_EXPERIMENTAL: enabled
-    steps:
-      - checkout
-      - run: *setup_dct_env
-      - run: *load_dct_keys
-      - run:
-          name: multiarch/qemu-user-static
-          command: DOCKER_CONTENT_TRUST=0 docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-      - run:
-          name: Push single-arch OCI
-          command: |
-            make publish ARCHITECTURE="<< parameters.architecture >>" \
-              CONTAINER_REGISTRY="${DOCKER_REGISTRY}" \
-              TAG_ORG="${DOCKER_ORG}" \
-              CONTAINER_REGISTRY_LOGIN="${DOCKERHUB_LOGIN}" \
-              CONTAINER_REGISTRY_PASS="${DOCKERHUB_PASS}" \
-              VERSION=${VERSION}
-
-  publish-multi-arch:
-    machine:
-      image: ubuntu-2204:2022.07.1
+      image: ubuntu-2204:current
     environment:
       DOCKER_CLI_EXPERIMENTAL: enabled
     steps:
@@ -87,7 +71,38 @@ jobs:
       - run:
           name: Login to DockerHub
           command: |
-            docker login -u ${DOCKERHUB_LOGIN} -p ${DOCKERHUB_PASS}
+            docker login -u "${DOCKERHUB_LOGIN}" -p "${DOCKERHUB_PASS}"
+      - run:
+          name: multiarch/qemu-user-static
+          command: DOCKER_CONTENT_TRUST=0 docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+      - run:
+          name: Push single-arch OCI
+          command: |
+            make publish \
+              ARCHITECTURE="<< parameters.architecture >>" \
+              JAVA_MAJOR_VERSION="<< parameters.jdk >>" \
+              CONTAINER_REGISTRY="${DOCKER_REGISTRY}" \
+              TAG_ORG="${DOCKER_ORG}" \
+              CONTAINER_REGISTRY_LOGIN="${DOCKERHUB_LOGIN}" \
+              CONTAINER_REGISTRY_PASS="${DOCKERHUB_PASS}" \
+              VERSION=${VERSION}
+
+  publish-multi-arch:
+    parameters:
+      jdk:
+        type: string
+    machine:
+      image: ubuntu-2204:current
+    environment:
+      DOCKER_CLI_EXPERIMENTAL: enabled
+    steps:
+      - checkout
+      - run: *setup_dct_env
+      - run: *load_dct_keys
+      - run:
+          name: Login to DockerHub
+          command: |
+            docker login -u "${DOCKERHUB_LOGIN}" -p "${DOCKERHUB_PASS}"
       - run:
           name: Install notary
           command: |
@@ -104,7 +119,8 @@ jobs:
       - run:
           name: Create & push multi-arch manifest
           command: |
-            IMAGE_REF="${IMAGE}:${VERSION}"
+            JAVA_MAJOR_VERSION="<< parameters.jdk >>"
+            IMAGE_REF="${IMAGE}:${VERSION}-jre-${JAVA_MAJOR_VERSION}"
             docker manifest create ${IMAGE_REF} \
               ${IMAGE_REF}-amd64 \
               ${IMAGE_REF}-arm64 \
@@ -114,7 +130,7 @@ jobs:
             echo "Manifest SHA-256: ${SHA_256}"
             echo "Image-Ref: ${IMAGE_REF}"
             MANIFEST_FROM_REG="$(docker manifest inspect "${IMAGE_REF}" -v)";
-            BYTES_SIZE="$(printf "${MANIFEST_FROM_REG}" | jq -r '.[].Descriptor.size' | uniq)";
+            BYTES_SIZE="$(printf "${MANIFEST_FROM_REG}" | jq -r '.[].Descriptor.size' | sort -nr | head -n1)";
             echo "Manifest-inspect BYTES: ${BYTES_SIZE}";
             echo "Manifest contents:\n";
             printf "${MANIFEST_FROM_REG}" | jq -r '.[].Descriptor | "Architecture: " + .platform.architecture + .platform.variant + ", digest: " + .digest';
@@ -140,21 +156,36 @@ workflows:
           matrix:
             parameters:
               architecture: [linux/amd64,linux/arm64,linux/arm/v7]
+              jdk: ["11", "17"]
           filters:
             branches:
-              ignore: master
+              ignore:
+                - master
+                - ranger/multi-jdk
       - publish-single-arch:
           matrix:
             parameters:
               architecture: [linux/amd64,linux/arm64,linux/arm/v7]
-          context: "docker-content-trust"
+              jdk: ["11", "17"]
+          context:
+            - "docker-content-trust"
+            - "docker-publish-account"
           filters:
             branches:
-              only: master
+              only:
+                - master
+                - ranger/multi-jdk
       - publish-multi-arch:
-          context: "docker-content-trust"
+          matrix:
+            parameters:
+              jdk: ["11", "17"]
+          context:
+            - "docker-content-trust"
+            - "docker-publish-account"
           requires:
             - publish-single-arch
           filters:
             branches:
-              only: master
+              only:
+                - master
+                - ranger/multi-jdk

--- a/Dockerfile.tpl
+++ b/Dockerfile.tpl
@@ -1,17 +1,16 @@
 ##
-# DO NOT EDIT: This file is generated from the Dockerfile.tpl
-##
-
-##
 # do some common things that all layers use, on top of the Ubuntu base; also
 # make sure security updates are installed
 ##
 FROM ${BASE_IMAGE} as core
 
+# We need to install inetutils-ping to get the JNI Pinger to work.
+# The JNI Pinger is tested with getprotobyname("icmp") and it is null if inetutils-ping is missing.
 RUN apt-get update && \
     env DEBIAN_FRONTEND="noninteractive" apt-get install --no-install-recommends -y \
         ca-certificates \
         curl \
+        gnupg \
         inetutils-ping \
         less \
         libcap2-bin \
@@ -21,9 +20,6 @@ RUN apt-get update && \
         vim-tiny \
     && \
     ln -sf vi /usr/bin/vim && \
-    env DEBIAN_FRONTEND="noninteractive" apt-get install --no-install-recommends -y \
-        "${JAVA_PKG}" \
-    && \
     grep security /etc/apt/sources.list > /tmp/security.sources.list && \
     apt-get update \
         -o Dir::Etc::SourceList=/tmp/security.sources.list && \
@@ -45,8 +41,6 @@ RUN apt-get update && \
         build-essential \
         dh-autoreconf \
         git-core \
-    && \
-    env DEBIAN_FRONTEND="noninteractive" apt-get install --no-install-recommends -y \
         openjdk-8-jdk-headless
 
 # Install build dependencies for JICMP and JICMP6
@@ -58,38 +52,42 @@ RUN git clone --depth 1 --branch "${JICMP_VERSION}" "${JICMP_GIT_REPO_URL}" /usr
     cd /usr/src/jicmp && \
     git submodule update --init --recursive --depth 1 && \
     autoreconf -fvi && \
-    ./configure && \
-    make -j1
+    ./configure
+RUN cd /usr/src/jicmp && make -j1
 
 # Checkout and build JICMP6
 RUN git clone --depth 1 --branch "${JICMP6_VERSION}" "${JICMP6_GIT_REPO_URL}" /usr/src/jicmp6 && \
     cd /usr/src/jicmp6 && \
     git submodule update --init --recursive --depth 1 && \
     autoreconf -fvi && \
-    ./configure && \
-    make -j1
+    ./configure
+RUN cd /usr/src/jicmp6 && make -j1
 
 ##
 # Assemble deploy base image with jicmp, jicmp6, confd and OpenJDK
 ##
 FROM core
 
-# Install OpenJDK 11 and create an architecture independent Java directory
-# which can be used as Java Home.
-# We need to install inetutils-ping. It is required to get the JNI Pinger to work.
-# The JNI Pinger is tested with getprotobyname("icmp") and it is null if inetutils-ping is missing
+# Install OpenJDK and create an architecture independent Java directory which can be used as Java Home.
 # To be able to use DGRAM to send ICMP messages we have to give the java binary CAP_NET_RAW capabilities in Linux.
 RUN apt-get update && \
-    DEBIAN_FRONTEND="noninteractive" apt-get install --no-install-recommends -y "${JAVA_PKG}" && \
-    ln -s /usr/lib/jvm/java-11-openjdk* "${JAVA_HOME}" && \
-    rm -rf /var/lib/apt/lists/* && \
+    env DEBIAN_FRONTEND="noninteractive" apt-get install --no-install-recommends -y "${JAVA_PKG}" && \
+    ln -s /usr/lib/jvm/java-${JAVA_MAJOR_VERSION}-openjdk* "${JAVA_HOME}" && \
     apt-get clean && \
-    rm -rf /var/cache/apt && \
-    \
-    mkdir -p /opt/prom-jmx-exporter && \
-    curl "${PROM_JMX_EXPORTER_URL}" --output /opt/prom-jmx-exporter/jmx_prometheus_javaagent.jar && \
-    \
-    setcap CAP_NET_BIND_SERVICE+ep "${JAVA_HOME}/bin/java" && \
+    rm -rf /var/cache/apt /var/lib/apt/lists/*
+
+# Preserve a pristine copy of the Java binaries before we apply setcap
+# Symlink to the other resources vs copying to keep the container image smaller
+RUN mkdir -p "/usr/lib/jvm/java-nocap" && \
+    cp -R "${JAVA_HOME}/bin" "/usr/lib/jvm/java-nocap/" && \
+    ln -s "${JAVA_HOME}/conf" "/usr/lib/jvm/java-nocap/conf" && \
+    ln -s "${JAVA_HOME}/docs" "/usr/lib/jvm/java-nocap/docs" && \
+    ln -s "${JAVA_HOME}/legal" "/usr/lib/jvm/java-nocap/legal" && \
+    ln -s "${JAVA_HOME}/lib" "/usr/lib/jvm/java-nocap/lib" && \
+    ln -s "${JAVA_HOME}/man" "/usr/lib/jvm/java-nocap/man" && \
+    ln -s "${JAVA_HOME}/release" "/usr/lib/jvm/java-nocap/release"
+
+RUN setcap CAP_NET_BIND_SERVICE+ep "${JAVA_HOME}/bin/java" && \
     echo "${JAVA_HOME}/lib/jli" > /etc/ld.so.conf.d/java-latest.conf && \
     ldconfig
 
@@ -115,6 +113,23 @@ COPY --from=jicmp-build /usr/src/jicmp6/.libs/libjicmp6.la /usr/lib/jni/
 COPY --from=jicmp-build /usr/src/jicmp6/.libs/libjicmp6.so /usr/lib/jni/
 COPY --from=jicmp-build /usr/src/jicmp6/jicmp6.jar /usr/share/java
 
+RUN mkdir -p /opt/prom-jmx-exporter && \
+    curl "${PROM_JMX_EXPORTER_URL}" --output /opt/prom-jmx-exporter/jmx_prometheus_javaagent.jar 
+
+ARG REPO_KEY_URL="https://debian.opennms.org/OPENNMS-GPG-KEY"
+
+# Prevent setup prompt
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Set up OpenNMS stable repository
+RUN apt-get update && \
+    env DEBIAN_FRONTEND="noninteractive" apt-get install --no-install-recommends -y \
+    software-properties-common && \
+    echo "deb https://debian.opennms.org stable main" > /etc/apt/sources.list.d/opennms.list && \
+    add-apt-repository -y 'deb http://debian.opennms.org stable main' && \
+    apt-get clean && \
+    rm -rf /var/cache/apt /var/lib/apt/lists/*
+
 LABEL org.opencontainers.image.created="${BUILD_DATE}" \
       org.opencontainers.image.title="OpenNMS deploy based on ${BASE_IMAGE}" \
       org.opencontainers.image.source="${VCS_SOURCE}" \
@@ -124,7 +139,7 @@ LABEL org.opencontainers.image.created="${BUILD_DATE}" \
       org.opencontainers.image.authors="OpenNMS Community" \
       org.opencontainers.image.licenses="AGPL-3.0" \
       org.opennms.image.base="${BASE_IMAGE}" \
-      org.opennms.image.java.version="${JAVA_PKG_VERSION}" \
+      org.opennms.image.java.version="${JAVA_MAJOR_VERSION}" \
       org.opennms.image.java.home="${JAVA_HOME}" \
       org.opennms.image.jicmp.version="${JICMP_VERSION}" \
       org.opennms.image.jicmp6.version="${JICMP6_VERSION}" \


### PR DESCRIPTION
will tag this as 3.0 once merged, since the dockerhub tag format changes to include the JDK

* add JDK parameter to the CircleCI matrix
* get rid of specific jdk version references
* rearrange the dockerfile a bit to simplify things
* include JDK version in tags and OCI files