### PR TITLE
Set multiple capabilities using a single setcap command (ubuntu)

### DIFF
--- a/Dockerfile.tpl
+++ b/Dockerfile.tpl
@@ -89,8 +89,7 @@ RUN mkdir -p "/usr/lib/jvm/java-nocap" && \
     ln -s "${JAVA_HOME}/man" "/usr/lib/jvm/java-nocap/man" && \
     ln -s "${JAVA_HOME}/release" "/usr/lib/jvm/java-nocap/release"
 
-RUN setcap CAP_NET_BIND_SERVICE+ep "${JAVA_HOME}/bin/java" && \
-    setcap CAP_NET_RAW+ep "${JAVA_HOME}/bin/java" && \
+RUN setcap "CAP_NET_BIND_SERVICE=+ep CAP_NET_RAW=+ep" "${JAVA_HOME}/bin/java" && \
     echo "${JAVA_HOME}/lib/jli" > /etc/ld.so.conf.d/java-latest.conf && \
     ldconfig
 


### PR DESCRIPTION
When we have multiple capabilities, we should use a single setcap command to set it;

If we don't do this, the second capability gets ignored.