### PR TITLE
fix: Remove unused Haveged repo url

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,8 +49,6 @@ JICMP6_VERSION            := jicmp6-3.0.0-2
 JATTACH_GIT_REPO_URL      := https://github.com/jattach/jattach
 JATTACH_VERSION           := v2.1
 
-HAVEGED_GIT_REPO_URL      := https://github.com/jirka-h/haveged
-
 CONFD_SOURCE              := https://github.com/abtreece/confd
 CONFD_VERSION             := 0.30.0
 


### PR DESCRIPTION
Modern Linux kernel adopted sophisticated algorithms to generate entropy and therefor Haved was removed. It seems like the variable in the Makefile is a left over and is never used in the Docker build process.